### PR TITLE
centauri wasm_client_data broken snapshot fix

### DIFF
--- a/modules/light-clients/08-wasm/keeper/keeper.go
+++ b/modules/light-clients/08-wasm/keeper/keeper.go
@@ -208,13 +208,13 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) types.GenesisState {
 // TODO: testing
 func (k Keeper) IterateCodeInfos(ctx sdk.Context, fn func(codeID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	prefixStore := prefix.NewStore(store, []byte(fmt.Sprintf("%s/", types.PrefixCodeIDKey)))
+	prefixStore := prefix.NewStore(store, types.PrefixCodeIDKey)
 
 	iter := prefixStore.Iterator(nil, nil)
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {
-		if fn(string(iter.Value())) {
+		if fn(string(iter.Key())) {
 			break
 		}
 	}


### PR DESCRIPTION
composable centaurid does not restore the contents of wasm_client_data

provide proper keys to snapshot exporder